### PR TITLE
fix: dbConfig not parsed

### DIFF
--- a/src/dependencies.ts
+++ b/src/dependencies.ts
@@ -9,7 +9,7 @@ const logConfig: LogConfig = {
 
 export const settings: Settings = settingsModel.parse({
     tokenId: process.env.tokenId,
-    dbConfig: process.env.db,
+    dbConfig: JSON.parse(process.env.db ?? ''),
     logConfig,
 });
 


### PR DESCRIPTION
Zod could not parse dbConfig because it was being passed as a string, not an object.