### PR TITLE
fix: only use webhook

### DIFF
--- a/src/forecastsBot.ts
+++ b/src/forecastsBot.ts
@@ -50,7 +50,5 @@ export const forecastsBot = (token: string) => {
     const assign = messageHandlerAssignator(bot);
     messageHandlers.forEach((handler) => assign(handler));
 
-    bot.start();
-
     return bot;
 };


### PR DESCRIPTION
`bot.start()` triggers polling. We only want to use a webhook.